### PR TITLE
Add link to band roster on Members page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pipeband",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/app/members/members.component.html
+++ b/src/app/members/members.component.html
@@ -110,6 +110,17 @@
                 </mat-list>
             </mat-card-content>
         </mat-card>
+        <mat-card>
+            <mat-card-header>
+                <mat-card-title>Band Roster</mat-card-title>
+            </mat-card-header>
+            <mat-card-content>
+                <p>
+                    You can download the latest copy of the band's roster here.  This file contains the active, associate, and student members of the band along with contact information. 
+                    <br><a href="../../assets/Band_Roster.xlsx" target="_blank" >Band Roster Excel Workbook</a>
+                </p>
+            </mat-card-content>
+        </mat-card>
     </div>
     <div class="left-article">
         <mat-card>


### PR DESCRIPTION
Add a list of band members with contact info to the Members only page.  Not committing the Excel workbook as it has sensitive info