### PR TITLE
Fix incorrect date for MN

### DIFF
--- a/src/app/schedule/schedule.component.html
+++ b/src/app/schedule/schedule.component.html
@@ -40,7 +40,7 @@
             <mat-list-item>
                 <span matListItemTitle><a href="https://www.mnscottishfair.org/" target="_blank" rel="noopener noreferrer">Minnesota Scottish Fair and Highland Games</a></span>
                 <span matListItemLine>Macalester College, St Paul, MN</span>
-                <span matListItemLine>June 15, 2024</span>
+                <span matListItemLine>July 13, 2024</span>
             </mat-list-item>
             <mat-list-item>
                 <span matListItemTitle><a href="https://eeckc.org/ethnic-enrichment-fest" target="_blank" rel="noopener noreferrer">Kansas City Ethnic Enrichment Festival</a></span>


### PR DESCRIPTION
Fix an incorrect date for the Minnesota contest on the `Performances` page.