### PR TITLE
Update Schedule to Remove Tulsa

### DIFF
--- a/src/app/schedule/schedule.component.html
+++ b/src/app/schedule/schedule.component.html
@@ -50,7 +50,7 @@
             <mat-list-item>
                 <span matListItemTitle><a href="https://eeckc.org/ethnic-enrichment-fest" target="_blank" rel="noopener noreferrer">Ethnic enrichment Festival</a></span>
                 <span matListItemLine>Kansas City, MO</span>
-                <span matListItemLine>Aug 16, 2025</span>
+                <span matListItemLine>Aug 16, 2025 5pm</span>
             </mat-list-item>
             <mat-list-item>
                 <span matListItemTitle><a href="https://www.kcirishfest.com/" target="_blank" rel="noopener noreferrer">Kansas City Irish Fest</a></span>
@@ -58,12 +58,7 @@
                 <span matListItemLine>Aug 29-31, 2025</span>
             </mat-list-item>
             <mat-list-item>
-                <span matListItemTitle><a href="https://okscotfest.com/" target="_blank" rel="noopener noreferrer">Oklahoma ScotFest</a></span>
-                <span matListItemLine>Broken Arrow, OK</span>
-                <span matListItemLine>Sep 20, 2025</span>
-            </mat-list-item>
-            <mat-list-item>
-                <span matListItemTitle><a href="https://exspgschamber.com/community/irishfest/" target="_blank" rel="noopener noreferrer">Excelsior Springs Irish Festival</a></span>
+                <span matListItemTitle><a href="https://exspgschamber.com/community/irishfest/" target="_blank" rel="noopener noreferrer">Shamrock Ranch and Winery Irish Festival</a></span>
                 <span matListItemLine>Excelsior Springs, MO</span>
                 <span matListItemLine>Oct 4-5, 2025</span>
             </mat-list-item>

--- a/src/index.html
+++ b/src/index.html
@@ -3,6 +3,9 @@
 <head>
   <meta charset="utf-8">
   <title>Kansas City St. Andrew Pipes & Drums</title>
+  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+  <meta http-equiv="Pragma" content="no-cache">
+  <meta http-equiv="Expires" content="0">
   <meta name="description" content="For 60+ years KC St. Andrew Pipes & Drums has been committed to development of piping and drumming. We're provide award-winning solo bagpipers, small ensembles, or even a full band for your event.">
   <meta property="og:title" content="Kansas City St. Andrew Pipes &amp; Drums"/>
   <meta property="og:description" content="For 60+ years KC St. Andrew Pipes & Drums has been committed to development of piping and drumming. We're provide award-winning solo bagpipers, small ensembles, or even a full band for your event."/>


### PR DESCRIPTION
Remove the canceled Tulsa Highland Games from our schedule.